### PR TITLE
Fix date field clearing issue when editing transactions

### DIFF
--- a/src/app/transactions/TransactionsPageClient.tsx
+++ b/src/app/transactions/TransactionsPageClient.tsx
@@ -18,7 +18,7 @@ import type {
 import { TransactionService } from '@/lib/transactions-client';
 import { MasterService } from '@/lib/masters-client';
 import { ImportExportService } from '@/lib/import-export-client';
-import { formatDate, debounce } from '@/lib/utils';
+import { formatDate, formatDateForInput, debounce } from '@/lib/utils';
 
 export const TransactionsPageClient: React.FC = () => {
   const { data: session } = useSession();
@@ -257,7 +257,7 @@ export const TransactionsPageClient: React.FC = () => {
           <Input
             label="開始日"
             type="date"
-            value={filter.startDate ? formatDate(filter.startDate) : ''}
+            value={filter.startDate ? formatDateForInput(filter.startDate) : ''}
             onChange={(e) => 
               handleFilterChange('startDate', e.target.value ? new Date(e.target.value) : undefined)
             }
@@ -265,7 +265,7 @@ export const TransactionsPageClient: React.FC = () => {
           <Input
             label="終了日"
             type="date"
-            value={filter.endDate ? formatDate(filter.endDate) : ''}
+            value={filter.endDate ? formatDateForInput(filter.endDate) : ''}
             onChange={(e) => 
               handleFilterChange('endDate', e.target.value ? new Date(e.target.value) : undefined)
             }
@@ -303,7 +303,7 @@ export const TransactionsPageClient: React.FC = () => {
           </h2>
           <TransactionForm
             initialData={editingTransaction ? {
-              date: formatDate(new Date(editingTransaction.date)),
+              date: formatDateForInput(new Date(editingTransaction.date)),
               paymentMethodId: editingTransaction.paymentMethodId,
               store: editingTransaction.store || undefined,
               purpose: editingTransaction.purpose || undefined,

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/Input';
 import { Select } from '@/components/ui/Select';
 import type { TransactionFormData, PaymentMethod } from '@/types';
 import { MasterService } from '@/lib/masters-client';
-import { formatDate, validateAmount } from '@/lib/utils';
+import { formatDateForInput, validateAmount } from '@/lib/utils';
 
 interface TransactionFormProps {
   initialData?: Partial<TransactionFormData>;
@@ -22,7 +22,7 @@ export const TransactionForm: React.FC<TransactionFormProps> = ({
   loading = false,
 }) => {
   const [formData, setFormData] = useState<TransactionFormData>({
-    date: initialData?.date || formatDate(new Date()),
+    date: initialData?.date || formatDateForInput(new Date()),
     paymentMethodId: initialData?.paymentMethodId || '',
     store: initialData?.store || '',
     purpose: initialData?.purpose || '',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,6 +9,14 @@ export const formatDate = (date: Date): string => {
   });
 };
 
+// HTML date input用のフォーマット（ISO 8601形式: YYYY-MM-DD）
+export const formatDateForInput = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 export const formatDateTime = (date: Date): string => {
   return date.toLocaleString('ja-JP', {
     year: 'numeric',


### PR DESCRIPTION
Fixes #26

The issue was that HTML date inputs require ISO format (YYYY-MM-DD) but the code was using Japanese locale format (YYYY/MM/DD).

## Changes
- Added `formatDateForInput() utility function for HTML date inputs
- Updated transaction editing to preserve original dates
- Fixed date filter inputs to use correct format

Generated with [Claude Code](https://claude.ai/code)