### PR TITLE
feat: カードフォームに締日・引き落とし月フィールドを追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,15 +132,17 @@ model PaymentMethod {
 }
 
 model Card {
-  id                 String   @id @default(cuid())
-  userId             String   @map("user_id")
-  name               String
-  type               CardType
-  withdrawalDay      Int      @map("withdrawal_day") // 1-31
-  withdrawalBankId   String   @map("withdrawal_bank_id")
-  isActive           Boolean  @default(true) @map("is_active")
-  createdAt          DateTime @default(now()) @map("created_at")
-  updatedAt          DateTime @updatedAt @map("updated_at")
+  id                    String   @id @default(cuid())
+  userId                String   @map("user_id")
+  name                  String
+  type                  CardType
+  closingDay            Int      @default(1) @map("closing_day")           // 1-31
+  withdrawalDay         Int      @map("withdrawal_day")                    // 1-31  
+  withdrawalMonthOffset Int      @default(1) @map("withdrawal_month_offset") // 1: 翌月, 2: 翌々月
+  withdrawalBankId      String   @map("withdrawal_bank_id")
+  isActive              Boolean  @default(true) @map("is_active")
+  createdAt             DateTime @default(now()) @map("created_at")
+  updatedAt             DateTime @updatedAt @map("updated_at")
 
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   withdrawalBank Bank            @relation("CardWithdrawalBank", fields: [withdrawalBankId], references: [id])

--- a/src/app/api/masters/cards/route.ts
+++ b/src/app/api/masters/cards/route.ts
@@ -37,7 +37,9 @@ export async function POST(request: NextRequest) {
     const data = {
       name: validatedData.name,
       type: validatedData.type,
+      closingDay: validatedData.closingDay,
       withdrawalDay: validatedData.withdrawalDay,
+      withdrawalMonthOffset: validatedData.withdrawalMonthOffset,
       withdrawalBankId: validatedData.withdrawalBankId,
       isActive: validatedData.isActive ?? true,
     };

--- a/src/app/masters/MastersPageClient.tsx
+++ b/src/app/masters/MastersPageClient.tsx
@@ -128,7 +128,9 @@ export const MastersPageClient: React.FC = () => {
     const cardData = {
       name: data.name,
       type: data.type,
+      closingDay: data.closingDay,
       withdrawalDay: data.withdrawalDay,
+      withdrawalMonthOffset: data.withdrawalMonthOffset,
       withdrawalBankId: data.withdrawalBankId,
       isActive: data.isActive ?? true,
     };

--- a/src/components/masters/CardForm.tsx
+++ b/src/components/masters/CardForm.tsx
@@ -23,7 +23,9 @@ export const CardForm: React.FC<CardFormProps> = ({
   const [formData, setFormData] = useState<CardFormData>({
     name: initialData?.name || '',
     type: initialData?.type || 'CREDIT_CARD',
+    closingDay: initialData?.closingDay || 1,
     withdrawalDay: initialData?.withdrawalDay || 1,
+    withdrawalMonthOffset: initialData?.withdrawalMonthOffset || 1,
     withdrawalBankId: initialData?.withdrawalBankId || '',
     isActive: initialData?.isActive !== undefined ? initialData.isActive : true,
   });
@@ -53,8 +55,16 @@ export const CardForm: React.FC<CardFormProps> = ({
       newErrors.type = 'カード種別を選択してください';
     }
 
+    if (!formData.closingDay || formData.closingDay < 1 || formData.closingDay > 31) {
+      newErrors.closingDay = '締日は1-31の間で入力してください';
+    }
+
     if (!formData.withdrawalDay || formData.withdrawalDay < 1 || formData.withdrawalDay > 31) {
       newErrors.withdrawalDay = '引き落とし日は1-31の間で入力してください';
+    }
+
+    if (!formData.withdrawalMonthOffset || (formData.withdrawalMonthOffset !== 1 && formData.withdrawalMonthOffset !== 2)) {
+      newErrors.withdrawalMonthOffset = '引き落とし月を選択してください';
     }
 
     if (!formData.withdrawalBankId) {
@@ -122,6 +132,32 @@ export const CardForm: React.FC<CardFormProps> = ({
           value={formData.type}
           onChange={(e) => handleInputChange('type', e.target.value as CardFormData['type'])}
           error={errors.type}
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Input
+          label="締日"
+          type="number"
+          min="1"
+          max="31"
+          value={formData.closingDay}
+          onChange={(e) => handleInputChange('closingDay', Number(e.target.value))}
+          error={errors.closingDay}
+          placeholder="例: 15"
+          required
+        />
+
+        <Select
+          label="引き落とし月"
+          options={[
+            { value: '1', label: '翌月' },
+            { value: '2', label: '翌々月' },
+          ]}
+          value={formData.withdrawalMonthOffset.toString()}
+          onChange={(e) => handleInputChange('withdrawalMonthOffset', Number(e.target.value))}
+          error={errors.withdrawalMonthOffset}
           required
         />
       </div>

--- a/src/components/masters/CardTable.tsx
+++ b/src/components/masters/CardTable.tsx
@@ -41,6 +41,10 @@ export const CardTable: React.FC<CardTableProps> = ({
     return typeMap[type] || type;
   };
 
+  const getWithdrawalMonthLabel = (offset: number) => {
+    return offset === 1 ? '翌月' : '翌々月';
+  };
+
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full bg-white border border-gray-200">
@@ -51,6 +55,12 @@ export const CardTable: React.FC<CardTableProps> = ({
             </th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
               種別
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
+              締日
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
+              引き落とし月
             </th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
               引き落とし日
@@ -74,6 +84,12 @@ export const CardTable: React.FC<CardTableProps> = ({
               </td>
               <td className="px-4 py-3 text-sm text-gray-900 border-b">
                 {getTypeLabel(card.type)}
+              </td>
+              <td className="px-4 py-3 text-sm text-gray-900 border-b">
+                {card.closingDay}日
+              </td>
+              <td className="px-4 py-3 text-sm text-gray-900 border-b">
+                {getWithdrawalMonthLabel(card.withdrawalMonthOffset)}
               </td>
               <td className="px-4 py-3 text-sm text-gray-900 border-b">
                 {card.withdrawalDay}日

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -59,7 +59,11 @@ export const cardSchema = z.object({
   type: z.enum(['CREDIT_CARD', 'PREPAID_CARD'], {
     required_error: 'カード種別を選択してください',
   }),
+  closingDay: z.number().min(1).max(31),
   withdrawalDay: z.number().min(1).max(31),
+  withdrawalMonthOffset: z.union([z.literal(1), z.literal(2)], {
+    errorMap: () => ({ message: '引き落とし月を選択してください' }),
+  }),
   withdrawalBankId: z.string().min(1, '引き落とし銀行を選択してください'),
   isActive: z.boolean().default(true),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -125,7 +125,9 @@ export interface PaymentMethodFormData {
 export interface CardFormData {
   name: string;
   type: 'CREDIT_CARD' | 'PREPAID_CARD';
+  closingDay: number;
   withdrawalDay: number;
+  withdrawalMonthOffset: number;
   withdrawalBankId: string;
   isActive?: boolean;
 }


### PR DESCRIPTION
カードフォームに不足していた締日と引き落とし月の入力フィールドを追加しました。

## 主な変更内容
- 締日（1-31日）と引き落とし月（翌月・翌々月）の入力フィールドを追加
- TypeScript型定義とバリデーションスキーマを更新
- PrismaスキーマのCardモデルに新フィールド追加
- カードテーブルに表示カラム追加
- APIルートとフロントエンドを新フィールドに対応

## データ互換性
既存のカードデータにはデフォルト値（締日:1日、引き落とし月:翌月）が自動設定されます。

Fixes #issue-9

Generated with [Claude Code](https://claude.ai/code)