### PR TITLE
feat: 取引管理の一覧表でカード取引の引落予定日を表示

### DIFF
--- a/src/components/transactions/TransactionTable.tsx
+++ b/src/components/transactions/TransactionTable.tsx
@@ -79,6 +79,9 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({
               支払い方法
             </th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
+              引落予定日
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
               店舗
             </th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
@@ -141,6 +144,15 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({
                     </span>
                   )}
                 </div>
+              </td>
+              <td className="px-4 py-3 text-sm text-gray-900 border-b">
+                {transaction.paymentMethod.type === 'CARD' && transaction.cardWithdrawalDate ? (
+                  <span className="text-blue-600">
+                    {formatDate(new Date(transaction.cardWithdrawalDate))}
+                  </span>
+                ) : (
+                  '-'
+                )}
               </td>
               <td className="px-4 py-3 text-sm text-gray-900 border-b">
                 {transaction.store || '-'}


### PR DESCRIPTION
・取引管理の一覧表で取引がカードの場合は引き落とし日を表示する

## 変更内容
- TransactionTableに「引落予定日」列を追加
- カード取引のみ引落予定日を表示、その他は「-」を表示
- 引落予定日は青色でハイライト表示

Closes #39

Generated with [Claude Code](https://claude.ai/code)