### PR TITLE
feat: カード取引の引き落とし予定日を新規作成時に自動計算・表示

### DIFF
--- a/src/components/transactions/TransactionTable.tsx
+++ b/src/components/transactions/TransactionTable.tsx
@@ -91,6 +91,9 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({
               金額
             </th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
+              引落予定日
+            </th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
               操作
             </th>
             {showHistoricalBalance && (
@@ -156,6 +159,15 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({
                   {transaction.type === TransactionType.INCOME ? '+' : '-'}
                   {formatCurrency(Number(transaction.amount))}
                 </span>
+              </td>
+              <td className="px-4 py-3 text-sm text-center border-b">
+                {transaction.paymentMethod.type === 'CARD' && transaction.cardWithdrawalDate ? (
+                  <span className="text-blue-600 font-medium">
+                    {formatDate(new Date(transaction.cardWithdrawalDate))}
+                  </span>
+                ) : (
+                  <span className="text-gray-400">-</span>
+                )}
               </td>
               <td className="px-4 py-3 text-sm text-center border-b">
                 <div className="flex space-x-2 justify-center">


### PR DESCRIPTION
カード取引の引き落とし予定日を新規作成時に自動計算・表示する機能を実装しました。

## 変更内容
- TransactionServiceにcalculateWithdrawalDate メソッドを追加
- createTransactionでカード取引の場合に引き落とし予定日を計算・設定
- TransactionTableに「引落予定日」列を追加
- カード取引のみ青色で引き落とし予定日を表示、その他は「-」

Closes #39

Generated with [Claude Code](https://claude.ai/code)