### PR TITLE
fix: カード取引の引き落とし予定日計算ロジックを修正

### DIFF
--- a/src/lib/card-withdrawal.ts
+++ b/src/lib/card-withdrawal.ts
@@ -189,10 +189,10 @@ export class CardWithdrawalService {
       const transactionDate = new Date(transaction.date);
       const closingDate = new Date(transactionDate.getFullYear(), transactionDate.getMonth(), card.closingDay);
       
-      // 締日を過ぎている場合は翌月の引き落とし
+      // 締日を過ぎている場合は翌月 + offsetの引き落とし
       let targetMonth: Date;
       if (transactionDate >= closingDate) {
-        targetMonth = new Date(transactionDate.getFullYear(), transactionDate.getMonth() + card.withdrawalMonthOffset, 1);
+        targetMonth = new Date(transactionDate.getFullYear(), transactionDate.getMonth() + 1 + card.withdrawalMonthOffset, 1);
       } else {
         targetMonth = new Date(transactionDate.getFullYear(), transactionDate.getMonth() + card.withdrawalMonthOffset - 1, 1);
       }
@@ -217,8 +217,10 @@ export class CardWithdrawalService {
     
     let withdrawalDate: Date;
     if (date >= closingDate) {
-      withdrawalDate = new Date(date.getFullYear(), date.getMonth() + card.withdrawalMonthOffset, card.withdrawalDay);
+      // 締日以降の取引 → 翌月 + withdrawalMonthOffset分後に引き落とし
+      withdrawalDate = new Date(date.getFullYear(), date.getMonth() + 1 + card.withdrawalMonthOffset, card.withdrawalDay);
     } else {
+      // 締日前の取引 → withdrawalMonthOffset分後に引き落とし
       withdrawalDate = new Date(date.getFullYear(), date.getMonth() + card.withdrawalMonthOffset - 1, card.withdrawalDay);
     }
 

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -252,9 +252,9 @@ export class TransactionService {
     let withdrawalMonth: number;
 
     if (txDate >= closingDate) {
-      // 締日以降の取引 → withdrawalMonthOffset分後に引き落とし
+      // 締日以降の取引 → 翌月 + withdrawalMonthOffset分後に引き落とし
       withdrawalYear = txYear;
-      withdrawalMonth = txMonth + card.withdrawalMonthOffset;
+      withdrawalMonth = txMonth + 1 + card.withdrawalMonthOffset;
     } else {
       // 締日前の取引 → (withdrawalMonthOffset - 1)分後に引き落とし
       withdrawalYear = txYear;


### PR DESCRIPTION
締日後の取引における月オフセット計算を正しく修正。

## 修正内容
- 締日後取引: 翌月 + オフセット (修正後)
- 締日前取引: 当月 + オフセット - 1 (既存のまま)

例: イオンカード(締日1日、引き落とし翌月2日)で7/30取引

修正前: 8/2 (不正確)
修正後: 9/2 (正しい)

## 変更箇所
- transactions.ts: 新規取引作成時の引き落とし日計算
- card-withdrawal.ts: 既存取引処理と月別グループ化

Closes #39

Generated with [Claude Code](https://claude.ai/code)